### PR TITLE
Add `pinned` label

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Use [github-label-sync](https://github.com/Financial-Times/github-label-sync) an
 
 1. [Get a new access token](https://github.com/settings/tokens/new?description=Sider+labels+sync&scopes=repo) in GitHub
 2. Set the new token above in your terminal, e.g. `export GITHUB_ACCESS_TOKEN=xxxxxx`
-3. Try to sync with dry-run mode: `npx github-label-sync sider/<repo> --allow-added-labels --dry-run`
-4. Sync actually: `npx github-label-sync sider/<repo> --allow-added-labels`
-5. [Delete the generated token](https://github.com/settings/tokens) on GitHub
+3. Try to sync with dry-run mode: `npx github-label-sync sider/.github --allow-added-labels --dry-run`
+4. Sync actually: `npx github-label-sync sider/.github --allow-added-labels`
+5. Check the synced labels on the [labels](https://github.com/sider/.github/labels) page
+6. Try to sync for other repositories: `npx github-label-sync sider/<repo> --allow-added-labels [--dry-run]`
+7. [Delete the generated token](https://github.com/settings/tokens) on GitHub
 
 Note that we should **always set `--allow-added-labels`** because existing labels would be deleted without it.

--- a/labels.json
+++ b/labels.json
@@ -40,6 +40,11 @@
     "description": "This doesn't seem right"
   },
   {
+    "name": "pinned",
+    "color": "c5def5",
+    "description": "Prevent to be closed"
+  },
+  {
     "name": "question",
     "color": "d876e3",
     "description": "Further information is requested"


### PR DESCRIPTION
This label is used for Stale bot.

You can confirm the label on <https://github.com/sider/.github/labels>.